### PR TITLE
Add more context to ctog.New errors

### DIFF
--- a/ctlog/ctlog.go
+++ b/ctlog/ctlog.go
@@ -20,6 +20,7 @@ package ctlog
 
 import (
 	"crypto"
+	"fmt"
 
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/logid"
@@ -41,11 +42,11 @@ type Log struct {
 func New(url, name, b64PubKey string) (*Log, error) {
 	id, err := logid.FromPubKeyB64(b64PubKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("logid.FromPubKeyB64(): %s", err)
 	}
 	pk, err := ct.PublicKeyFromB64(b64PubKey)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ct.PublicKeyFromB64(): %s", err)
 	}
 	return &Log{
 		ID:        id,


### PR DESCRIPTION
When running tests, I found myself looking at an error from ctlog.New, and it wasn't immediately clear that it was the public key parsing causing the problem.  Adding more info to returned errors to improve this.