### PR TITLE
Refactor collector and getters to reduce code duplication

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -32,7 +32,7 @@ import (
 	"github.com/google/monologue/ctlog"
 	"github.com/google/monologue/roots"
 	"github.com/google/monologue/schedule"
-	"github.com/google/monologue/sthgetter"
+	"github.com/google/monologue/sth"
 	"github.com/google/monologue/storage/print"
 )
 
@@ -86,7 +86,7 @@ func main() {
 		{
 			name: "STH Getter",
 			get: func(ctx context.Context, lc *client.LogClient, st *print.Storage, l *ctlog.Log) error {
-				if _, err := sthgetter.GetSTH(ctx, l, lc, st); err != nil {
+				if _, err := sth.Get(ctx, l, lc, st); err != nil {
 					return err
 				}
 				// TODO(katjoyce): Check and store STH

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/google/monologue/client"
 	"github.com/google/monologue/ctlog"
-	"github.com/google/monologue/rootsgetter"
+	"github.com/google/monologue/roots"
 	"github.com/google/monologue/schedule"
 	"github.com/google/monologue/sthgetter"
 	"github.com/google/monologue/storage/print"
@@ -74,7 +74,7 @@ func main() {
 		{
 			name: "Roots Getter",
 			get: func(ctx context.Context, lc *client.LogClient, st *print.Storage, l *ctlog.Log) error {
-				_, err := rootsgetter.GetRoots(ctx, l, lc, st)
+				_, err := roots.Get(ctx, l, lc, st)
 				if err != nil {
 					return err
 				}

--- a/roots/roots.go
+++ b/roots/roots.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package rootsgetter periodically queries a Log for its set of acceptable root certificates and stores them.
-package rootsgetter
+// Package roots provides functions for fetching and handling root certificates from Certificate Transparency Logs.
+package roots
 
 import (
 	"context"
@@ -28,15 +28,13 @@ import (
 	"github.com/google/monologue/storage"
 )
 
-const logStr = "Roots Getter"
-
-// GetRoots fetches the current root certificates trusted by a Log, using the given client.
+// Get fetches the current root certificates trusted by a Log, using the given client.
 // Records details of the get-roots API call to the provided storage.
-func GetRoots(ctx context.Context, l *ctlog.Log, lc *client.LogClient, st storage.APICallWriter) ([]*x509.Certificate, error) {
-	log.Printf("%s: %s: getting roots...", l.URL, logStr)
+func Get(ctx context.Context, l *ctlog.Log, lc *client.LogClient, st storage.APICallWriter) ([]*x509.Certificate, error) {
+	log.Printf("%s: getting roots...", l.URL)
 	roots, httpData, getErr := lc.GetRoots()
 
-	log.Printf("%s: %s: writing get-roots API Call...", l.URL, logStr)
+	log.Printf("%s: writing get-roots API Call...", l.URL)
 	apiCall := apicall.New(ct.GetRootsStr, httpData, getErr)
 	if err := st.WriteAPICall(ctx, l, apiCall); err != nil {
 		return nil, fmt.Errorf("error writing API Call %s: %s", apiCall, err)
@@ -46,6 +44,6 @@ func GetRoots(ctx context.Context, l *ctlog.Log, lc *client.LogClient, st storag
 		return nil, fmt.Errorf("error getting roots: %s", getErr)
 	}
 
-	log.Printf("%s: %s: get-roots response: %d certificates", l.URL, logStr, len(roots))
+	log.Printf("%s: get-roots response: %d certificates", l.URL, len(roots))
 	return roots, nil
 }

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -6,11 +6,13 @@ import (
 )
 
 // Every will call f periodically.
+// The first call will be made immediately.
 func Every(ctx context.Context, period time.Duration, f func(context.Context)) {
 	if ctx.Err() != nil {
 		return
 	}
-
+	// Run f immediately, then use a Ticker to periodically call it again.
+	f(ctx)
 	t := time.NewTicker(period)
 	defer t.Stop()
 	for {

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -1,0 +1,25 @@
+package schedule
+
+import (
+	"context"
+	"time"
+)
+
+// Every will call f periodically.
+func Every(ctx context.Context, period time.Duration, f func(context.Context)) {
+	if ctx.Err() != nil {
+		return
+	}
+
+	t := time.NewTicker(period)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			// TODO(katjoyce): Work out when and where to add context timeouts.
+			f(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/sth/sth.go
+++ b/sth/sth.go
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package sthgetter periodically gets an STH from a Log, checks that each one
-// meets per-STH requirements defined in RFC 6962, and stores them.
-package sthgetter
+// Package sth provides functions for fetching and validating STHs (Signed Tree Heads) from Certificate Transparency Logs (see RFC 6962).
+package sth
 
 import (
 	"context"
@@ -28,15 +27,13 @@ import (
 	"github.com/google/monologue/storage"
 )
 
-const logStr = "STH Getter"
-
-// GetSTH fetches the latest Signed Tree Head from a Log, using the given client.
+// Get fetches the latest Signed Tree Head from a Log, using the given client.
 // Records details of the get-sth API call to the provided storage.
-func GetSTH(ctx context.Context, l *ctlog.Log, lc *client.LogClient, store storage.APICallWriter) (*ct.SignedTreeHead, error) {
-	log.Printf("%s: %s: getting STH...", l.URL, logStr)
+func Get(ctx context.Context, l *ctlog.Log, lc *client.LogClient, store storage.APICallWriter) (*ct.SignedTreeHead, error) {
+	log.Printf("%s: getting STH...", l.URL)
 	sth, httpData, getErr := lc.GetSTH()
 
-	log.Printf("%s: %s: writing get-sth API Call...", l.URL, logStr)
+	log.Printf("%s: writing get-sth API Call...", l.URL)
 	apiCall := apicall.New(ct.GetSTHStr, httpData, getErr)
 	if err := store.WriteAPICall(ctx, l, apiCall); err != nil {
 		return nil, fmt.Errorf("error writing API Call %s: %s", apiCall, err)
@@ -47,7 +44,7 @@ func GetSTH(ctx context.Context, l *ctlog.Log, lc *client.LogClient, store stora
 	}
 
 	if len(httpData.Body) > 0 {
-		log.Printf("%s: %s: response: %s", l.URL, logStr, httpData.Body)
+		log.Printf("%s: get-sth response: %s", l.URL, httpData.Body)
 	}
 
 	return sth, nil


### PR DESCRIPTION
The prior code structure made it hard to avoid duplicating code. All getters would need a `Run()` method with almost identical code; the core logic of this method has been extracted into a new `schedule` package, and the logging and asynchronous aspects have moved to the `collector`.

The unexported "do everything" func that the getters had have been decomposed into funcs that have only one job and can report errors. The collector now assembles these funcs as desired to achieve its goals. This gives it greater control and flexibility.

This also makes a small behavioural change - getters will run immediately, rather than waiting for their configured period to elapse.