### PR TITLE
Store root certificates fetched by rootsgetter

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -51,6 +51,7 @@ type Config struct {
 // modules that the collector runs (e.g. sthgetter, rootsgetter etc).
 type Storage interface {
 	storage.APICallWriter
+	storage.RootsWriter
 	storage.STHWriter
 }
 

--- a/rootsgetter/rootsgetter.go
+++ b/rootsgetter/rootsgetter.go
@@ -17,6 +17,8 @@ package rootsgetter
 
 import (
 	"context"
+	"crypto/x509"
+	"fmt"
 	"time"
 
 	"github.com/golang/glog"
@@ -30,32 +32,44 @@ import (
 
 const logStr = "Roots Getter"
 
+// Storage interface required by Roots Getter.
+type Storage interface {
+	storage.APICallWriter
+	storage.RootsWriter
+}
+
 // Run starts an STH Getter, which periodically queries a Log for its set of acceptable root certificates and stores them.
-func Run(ctx context.Context, lc *client.LogClient, st storage.APICallWriter, l *ctlog.Log, period time.Duration) {
+func Run(ctx context.Context, lc *client.LogClient, st Storage, l *ctlog.Log, period time.Duration) {
 	glog.Infof("%s: %s: started with period %v", l.URL, logStr, period)
 
 	schedule.Every(ctx, period, func(ctx context.Context) {
-		getAndStoreRoots(ctx, lc, st, l)
+		roots, receivedAt, err := getRoots(ctx, lc, st, l)
+		if err != nil {
+			glog.Errorf("%s: %s: %s", l.URL, logStr, err)
+		}
+		if err := st.WriteRoots(ctx, l, roots, receivedAt); err != nil {
+			glog.Errorf("%s: %s: %s", l.URL, logStr, err)
+		}
 	})
 
 	glog.Infof("%s: %s: stopped", l.URL, logStr)
 }
 
-func getAndStoreRoots(ctx context.Context, lc *client.LogClient, st storage.APICallWriter, l *ctlog.Log) {
+func getRoots(ctx context.Context, lc *client.LogClient, st storage.APICallWriter, l *ctlog.Log) ([]*x509.Certificate, time.Time, error) {
 	glog.Infof("%s: %s: getting roots...", l.URL, logStr)
 	roots, httpData, getErr := lc.GetRoots()
-	if getErr != nil {
-		glog.Infof("%s: %s: error getting roots: %s", l.URL, logStr, getErr)
-	} else {
-		glog.Infof("%s: %s: response: %d certificates", l.URL, logStr, len(roots))
-	}
 
 	// Store get-roots API call.
 	apiCall := apicall.New(ct.GetRootsStr, httpData, getErr)
 	glog.Infof("%s: %s: writing API Call...", l.URL, logStr)
 	if err := st.WriteAPICall(ctx, l, apiCall); err != nil {
-		glog.Infof("%s: %s: error writing API Call %s: %s", l.URL, logStr, apiCall, err)
+		return nil, httpData.Timing.End, fmt.Errorf("error writing API Call %s: %s", apiCall, err)
 	}
 
-	//TODO(RJPercival): Store roots.
+	if getErr != nil {
+		return nil, httpData.Timing.End, fmt.Errorf("error getting roots: %s", getErr)
+	}
+
+	glog.Infof("%s: %s: response: %d certificates", l.URL, logStr, len(roots))
+	return roots, httpData.Timing.End, nil
 }

--- a/storage/print/print.go
+++ b/storage/print/print.go
@@ -22,6 +22,7 @@ package print
 
 import (
 	"context"
+	"crypto/x509"
 	"time"
 
 	"github.com/golang/glog"
@@ -42,5 +43,11 @@ func (s *Storage) WriteAPICall(ctx context.Context, l *ctlog.Log, apiCall *apica
 // WriteSTH simply prints the STH and errors passed to it.
 func (s *Storage) WriteSTH(ctx context.Context, l *ctlog.Log, sth *ct.SignedTreeHead, receivedAt time.Time, errs []error) error {
 	glog.Infof("%s:\n\tSTH: %s\n\tVerification errors: %s", l.Name, sth, errs)
+	return nil
+}
+
+// WriteRoots simply prints the number of certificates passed to it.
+func (s *Storage) WriteRoots(ctx context.Context, l *ctlog.Log, certs []*x509.Certificate, receivedAt time.Time) error {
+	glog.Infof("%s at %s: %d root certificates", l.Name, receivedAt, len(certs))
 	return nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,6 +18,7 @@ package storage
 
 import (
 	"context"
+	"crypto/x509"
 	"time"
 
 	ct "github.com/google/certificate-transparency-go"
@@ -34,4 +35,9 @@ type APICallWriter interface {
 // STHWriter is an interface for storing STHs received from a CT Log.
 type STHWriter interface {
 	WriteSTH(ctx context.Context, l *ctlog.Log, sth *ct.SignedTreeHead, receivedAt time.Time, errs []error) error
+}
+
+// RootsWriter is an interface for storing root certificates retrieved from a CT get-roots call.
+type RootsWriter interface {
+	WriteRoots(ctx context.Context, l *ctlog.Log, roots []*x509.Certificate, receivedAt time.Time) error
 }


### PR DESCRIPTION
Just uses `print.Storage` at the moment, which simply prints out the number of root certificates (no storing of certificates actually occurs). A new storage implementation will actually store the certificates in the future.