### PR TITLE
Create roots analyzer

### DIFF
--- a/incident/testonly/fake.go
+++ b/incident/testonly/fake.go
@@ -1,0 +1,68 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testonly contains fakes for use in tests that interact with incident reporting.
+package testonly
+
+import (
+	"context"
+	"fmt"
+)
+
+// Report contains all of the information submitted when creating an incident report.
+type Report struct {
+	BaseURL  string
+	Summary  string
+	Category string
+	FullURL  string
+	Details  string
+}
+
+// FakeReporter sends incident reports to its Reports channel.
+type FakeReporter struct {
+	Updates    chan Report
+	Violations chan Report
+}
+
+// LogUpdate sends an incident report to the FakeReporter's Updates channel.
+func (f *FakeReporter) LogUpdate(ctx context.Context, baseURL, summary, category, fullURL, details string) {
+	f.Updates <- Report{
+		BaseURL:  baseURL,
+		Summary:  summary,
+		Category: category,
+		FullURL:  fullURL,
+		Details:  details,
+	}
+}
+
+// LogUpdatef sends an incident report to the FakeReporter's Updates channel, formatting parameters along the way.
+func (f *FakeReporter) LogUpdatef(ctx context.Context, baseURL, summary, category, fullURL, detailsFmt string, args ...interface{}) {
+	f.LogUpdate(ctx, baseURL, summary, category, fullURL, fmt.Sprintf(detailsFmt, args...))
+}
+
+// LogViolation sends an incident report to the FakeReporter's Violations channel.
+func (f *FakeReporter) LogViolation(ctx context.Context, baseURL, summary, category, fullURL, details string) {
+	f.Violations <- Report{
+		BaseURL:  baseURL,
+		Summary:  summary,
+		Category: category,
+		FullURL:  fullURL,
+		Details:  details,
+	}
+}
+
+// LogViolationf sends an incident report to the FakeReporter's Violations channel, formatting parameters along the way.
+func (f *FakeReporter) LogViolationf(ctx context.Context, baseURL, summary, category, fullURL, detailsFmt string, args ...interface{}) {
+	f.LogViolation(ctx, baseURL, summary, category, fullURL, fmt.Sprintf(detailsFmt, args...))
+}

--- a/rootsanalyzer/rootsanalyzer.go
+++ b/rootsanalyzer/rootsanalyzer.go
@@ -1,0 +1,158 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package rootsanalyzer reports on changes in the set of root certificates
+// returned by a CT Log's get-roots endpoint.
+package rootsanalyzer
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/golang/glog"
+	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go/x509"
+	"github.com/google/monologue/ctlog"
+	"github.com/google/monologue/incident"
+	"github.com/google/monologue/storage"
+)
+
+const logStr = "Roots Analyzer"
+
+var (
+	incidentTemplate = template.Must(template.New("roots_incident").Funcs(template.FuncMap{
+		"sha256": sha256.Sum256,
+	}).Parse(`The root certificates accepted by {{ .Log.Name }} ({{ .Log.URL }}) have changed.
+{{ if gt (len .AddedCerts) 0 }}
+Certificates added ({{ len .AddedCerts }}):
+{{ range .AddedCerts }}{{ .Subject }} (SHA256: {{ sha256 .Raw | printf "%X" }})
+{{ end }}{{ end }}{{ if gt (len .RemovedCerts) 0 }}
+Certificates removed ({{ len .RemovedCerts }}):
+{{ range .RemovedCerts }}{{ .Subject }} (SHA256: {{ sha256 .Raw | printf "%X" }})
+{{ end }}{{ end }}`))
+)
+
+type incidentTemplateArgs struct {
+	Log          *ctlog.Log
+	AddedCerts   []*x509.Certificate
+	RemovedCerts []*x509.Certificate
+}
+
+// Run starts a Roots Analyzer, which watches a CT log's root certificates and creates incident reports for changes to them.
+func Run(ctx context.Context, st storage.RootsReader, rep incident.Reporter, l *ctlog.Log) {
+	rootSetChan, err := st.WatchRoots(ctx, l)
+	if err != nil {
+		glog.Errorf("%s: %s: storage.RootsReader.WatchRoots() = %q", l.URL, logStr, err)
+		return
+	}
+
+	var lastRootSetID storage.RootSetID
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case rootSetID := <-rootSetChan:
+			if lastRootSetID != "" && lastRootSetID != rootSetID {
+				// TODO(RJPercival): If the root set is flapping back to what it recently was, suppress sending an incident report
+				// since it could just be the result of skew between log frontends. However, if it doesn't flap back to the new
+				// root set again within a certain amount of time, then the suppressed report should be sent.
+				oldRoots, err := st.ReadRoots(ctx, lastRootSetID)
+				if err != nil {
+					glog.Errorf("%s: %s: %s", l.URL, logStr, err)
+					return
+				}
+				newRoots, err := st.ReadRoots(ctx, rootSetID)
+				if err != nil {
+					glog.Errorf("%s: %s: %s", l.URL, logStr, err)
+					return
+				}
+				addedCerts, removedCerts := diffRootSets(oldRoots, newRoots)
+				if err := reportChange(ctx, rep, l, addedCerts, removedCerts); err != nil {
+					glog.Errorf("%s: %s: %s", l.URL, logStr, err)
+					return
+				}
+			}
+			lastRootSetID = rootSetID
+		}
+	}
+}
+
+// diffRootSets returns the certificates that have been added or removed in new, relative to old.
+// Neither old nor new are allowed to contain duplicates.
+func diffRootSets(old, new []*x509.Certificate) (added, removed []*x509.Certificate) {
+	oldSet := make(map[string]*x509.Certificate, len(old))
+	for _, cert := range old {
+		oldSet[string(cert.Raw)] = cert
+	}
+	// This algorithm assumes that there are no duplicates in new.
+	// TODO(RJPercival): Support old and new containing duplicate certificates.
+	for _, cert := range new {
+		certDER := string(cert.Raw)
+		if oldSet[certDER] != nil {
+			// cert appears in both old and new - remove it from oldSet
+			// so that, after the loop, oldSet contains only certs
+			// that are in old but not new.
+			delete(oldSet, certDER)
+		} else {
+			// cert is only in new.
+			added = append(added, cert)
+		}
+	}
+	for _, cert := range oldSet {
+		removed = append(removed, cert)
+	}
+	return added, removed
+}
+
+// sortCerts sorts a slice of certificates first by their subject, then by their raw DER.
+func sortCerts(certs []*x509.Certificate) {
+	sort.Slice(certs, func(i, j int) bool {
+		if subj1, subj2 := certs[i].Subject.String(), certs[j].Subject.String(); subj1 != subj2 {
+			return subj1 < subj2
+		}
+		return bytes.Compare(certs[i].Raw, certs[j].Raw) < 0
+	})
+}
+
+func reportChange(ctx context.Context, rep incident.Reporter, l *ctlog.Log, addedCerts, removedCerts []*x509.Certificate) error {
+	fullURL := l.URL
+	getRootsURL, err := url.Parse(l.URL)
+	if err != nil {
+		glog.Errorf("%s: %s: failed to parse CT Log URL: %v", l.URL, logStr, err)
+	} else {
+		getRootsURL.Path = path.Join(getRootsURL.Path, ct.GetRootsPath)
+		fullURL = getRootsURL.String()
+	}
+
+	// Sort certs so that the report is deterministic - makes testing easier.
+	sortCerts(addedCerts)
+	sortCerts(removedCerts)
+
+	var strBuilder strings.Builder
+	if err := incidentTemplate.Execute(&strBuilder, incidentTemplateArgs{
+		Log:          l,
+		AddedCerts:   addedCerts,
+		RemovedCerts: removedCerts,
+	}); err != nil {
+		return err
+	}
+	rep.LogUpdate(ctx, l.URL, "Root certificates changed", "roots", fullURL, strBuilder.String())
+	return nil
+}

--- a/rootsanalyzer/rootsanalyzer_test.go
+++ b/rootsanalyzer/rootsanalyzer_test.go
@@ -1,0 +1,206 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rootsanalyzer
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/google/certificate-transparency-go/x509"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/monologue/ctlog"
+	"github.com/google/monologue/storage"
+
+	itestonly "github.com/google/monologue/incident/testonly"
+	stestonly "github.com/google/monologue/storage/testonly"
+)
+
+var (
+	root1 = mustParseCert(`MIIH/jCCBeagAwIBAgIBADANBgkqhkiG9w0BAQUFADCB1DELMAkGA1UEBhMCQVQxDzANBgNVBAcTBlZpZW5uYTEQMA4GA1UECBMHQXVzdHJpYTE6MDgGA1UEChMxQVJHRSBEQVRFTiAtIEF1c3RyaWFuIFNvY2lldHkgZm9yIERhdGEgUHJvdGVjdGlvbjEqMCgGA1UECxMhR0xPQkFMVFJVU1QgQ2VydGlmaWNhdGlvbiBTZXJ2aWNlMRQwEgYDVQQDEwtHTE9CQUxUUlVTVDEkMCIGCSqGSIb3DQEJARYVaW5mb0BnbG9iYWx0cnVzdC5pbmZvMB4XDTA2MDgwNzE0MTIzNVoXDTM2MDkxODE0MTIzNVowgdQxCzAJBgNVBAYTAkFUMQ8wDQYDVQQHEwZWaWVubmExEDAOBgNVBAgTB0F1c3RyaWExOjA4BgNVBAoTMUFSR0UgREFURU4gLSBBdXN0cmlhbiBTb2NpZXR5IGZvciBEYXRhIFByb3RlY3Rpb24xKjAoBgNVBAsTIUdMT0JBTFRSVVNUIENlcnRpZmljYXRpb24gU2VydmljZTEUMBIGA1UEAxMLR0xPQkFMVFJVU1QxJDAiBgkqhkiG9w0BCQEWFWluZm9AZ2xvYmFsdHJ1c3QuaW5mbzCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANISR+xfmOgNhhVJxN3snvFszVG2+5VPi8SQPVMzsdMTxUjipb/19AOED5x4cfaSl/FbWXUYPycLUS9caMeh6wDz9pU9acN+wqzECjZyelum0PcBeyjHKscyYO5ZuNcLJ92zRQUre2Snc1zokwKXaOz8hNue1NWBR8acwKyXyxnqh6UKo7h1JOdQJw2rFvlWXbGBARZ98+nhJPMIIbm6rF2ex0h5f2rK3zl3BG0bbjrNf85cSKwSPFnyas+ASOH2AGd4IOD9tWR7F5ez5SfdRWubYZkGvvLnnqRtiztrDIHutG+hvhoSQUuerQ75RrRa0QMAlBbAwPOs+3y8lsAp2PkzFomjDh2V2QPUIQzdVghJZciNqyEfVLuZvPFEW3sAGP0qGVjSBcnZKTYl/nfua1lUTwgUopkJRVetB94i/IccoO+ged0KfcB/NegMZk3jtWoWWXFb85CwUl6RAseoucIEb55PtAAt7AjsrkBu8CknIjm2zaCGELoLNex7Wg22ecP6x63B++vtK4QN6t7565pZM2zBKxKMuD7FNiM4GtZ3k5DWd3VqWBkXoRWObnYOo3PhXJVJ28EPlBTF1WIbmas41Wdu0qkZ4Vo6h2pIP5GW48bFJ2tXdDGY9j5xce1+3rBNLPPuj9t7aNcQRCmt7KtQWVKabGpyFE0WFFH3134fAgMBAAGjggHXMIIB0zAdBgNVHQ4EFgQUwAHV4HgfL3Q64+vAIVKmBO4my6QwggEBBgNVHSMEgfkwgfaAFMAB1eB4Hy90OuPrwCFSpgTuJsukoYHapIHXMIHUMQswCQYDVQQGEwJBVDEPMA0GA1UEBxMGVmllbm5hMRAwDgYDVQQIEwdBdXN0cmlhMTowOAYDVQQKEzFBUkdFIERBVEVOIC0gQXVzdHJpYW4gU29jaWV0eSBmb3IgRGF0YSBQcm90ZWN0aW9uMSowKAYDVQQLEyFHTE9CQUxUUlVTVCBDZXJ0aWZpY2F0aW9uIFNlcnZpY2UxFDASBgNVBAMTC0dMT0JBTFRSVVNUMSQwIgYJKoZIhvcNAQkBFhVpbmZvQGdsb2JhbHRydXN0LmluZm+CAQAwDwYDVR0TAQH/BAUwAwEB/zALBgNVHQ8EBAMCAcYwEQYDVR0gBAowCDAGBgRVHSAAMD0GA1UdEQQ2MDSBFWluZm9AZ2xvYmFsdHJ1c3QuaW5mb4YbaHR0cDovL3d3dy5nbG9iYWx0cnVzdC5pbmZvMD0GA1UdEgQ2MDSBFWluZm9AZ2xvYmFsdHJ1c3QuaW5mb4YbaHR0cDovL3d3dy5nbG9iYWx0cnVzdC5pbmZvMA0GCSqGSIb3DQEBBQUAA4ICAQAVO4iDXg7ePvA+XdwtoUr6KKXWB6UkSM6eeeh5mlwkjlhyFEGFx0XuPChpOEmuIo27jAVtrmW7h7l+djsoY2rWbzMwiH5VBbq5FQOYHWLSzsAPbhyaNO7krx9i0ey0ec/PaZKKWP3Bx3YLXM1SNEhr5Qt/yTIS35gKFtkzVhaP30M/170/xR7FrSGshyya5BwfhQOsi8e3M2JJwfiqK05dhz52Uq5ZfjHhfLpSi1iQ14BGCzQ23u8RyVwiRsI8p39iBG/fPkiO6gs+CKwYGlLW8fbUYi8DuZrWPFN/VSbGNSshdLCJkFTkAYhcnIUqmmVeS1fygBzsZzSaRtwCdv5yN3IJsfAjj1izAn3ueA65PXMSLVWfF2Ovrtiuc7bHUGqFwdt9+5RZcMbDB2xWxbAH/E59kx25J8CwldXnfAW89w8Ks/RuFVdJG7UUAKQwK1r0Vli/djSiPf4BJvDduG3wpOe8IPZRCPbjN4lXNvb3L/7NuGS96tem0P94737hHB5Ufg80GYEQc9LjeAYXttJR+zV4dtp3gzdBPi1GqH6G3lb0ypCetK2wHkUYPDSIAofo8DaR6/LntdIEuS64XY0dmi4LFhnNdqSr+9Hio6LchH176lDq9bIEO4lSOrLDGU+5JrG8vCyy4YGms2G19EVgLyx1xcgtiEsmu3DuO38BLQ==`)
+	root2 = mustParseCert(`MIIDyzCCArOgAwIBAgIDAOJIMA0GCSqGSIb3DQEBBQUAMIGLMQswCQYDVQQGEwJBVDFIMEYGA1UECgw/QS1UcnVzdCBHZXMuIGYuIFNpY2hlcmhlaXRzc3lzdGVtZSBpbSBlbGVrdHIuIERhdGVudmVya2VociBHbWJIMRgwFgYDVQQLDA9BLVRydXN0LVF1YWwtMDIxGDAWBgNVBAMMD0EtVHJ1c3QtUXVhbC0wMjAeFw0wNDEyMDIyMzAwMDBaFw0xNDEyMDIyMzAwMDBaMIGLMQswCQYDVQQGEwJBVDFIMEYGA1UECgw/QS1UcnVzdCBHZXMuIGYuIFNpY2hlcmhlaXRzc3lzdGVtZSBpbSBlbGVrdHIuIERhdGVudmVya2VociBHbWJIMRgwFgYDVQQLDA9BLVRydXN0LVF1YWwtMDIxGDAWBgNVBAMMD0EtVHJ1c3QtUXVhbC0wMjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAJaRq9eOsFm4Ab20Hq2Z/aH86gyWa48uSUjY6eQkguHYuszr3gdcSMYZggFHQgnhfLmfro/27l5rqKhWiDhWs+b+yZ1PNDhRPJy+86ycHMg9XJqErveULBSyZDdgjhSwOyrNibUir/fkf+4sKzP5jjytTKJXD/uCxY4fAd9TjMEVpN3umpIS0ijpYhclYDHvzzGU833z5Dwhq5D8bc9jp8YSAHFJ1xzIoO1jmn3jjyjdYPnY5harJtHQL73nDQnfbtTs5ThT9GQLulrMgLU4WeyAWWWEMWpfVZFMJOUkmoOEer6A8e5fIAeqdxdsC+JVqpZ4CAKel/Arrlj1gFA//jsCAwEAAaM2MDQwDwYDVR0TAQH/BAUwAwEB/zARBgNVHQ4ECgQIQj0rJKbBRc4wDgYDVR0PAQH/BAQDAgEGMA0GCSqGSIb3DQEBBQUAA4IBAQBGyxFjUA2bPkXUSC2SfJ29tmrbiLKal+g6a9M8Xwd+Ejo+oYkNP6F4GfeDtAXpm7xb9Ly8lhdbHcpRhzCUQHJ1tBCiGdLgmhSx7TXjhhanKOdDgkdsC1T+++piuuYL72TDgUy2Sb1GHlJ1Nc6rvB4fpxSDAOHqGpUq9LWsc3tFkXqRqmQVtqtR77npKIFBioc62jTBwDMPX3hDJDR1DSPc6BnZliaNw2IHdiMQ0mBoYeRnFdq+TyDKsjmJOOQPLzzL/saaw6F891+gBjLFEFquDyR73lAPJS279R3csi8WWk4ZYUC/1V8H3Ktip/J6ac8eqhLCbmJ81Lo92JGHz/ot`)
+)
+
+func mustParseCert(b64CertDER string) *x509.Certificate {
+	certDER, err := base64.StdEncoding.DecodeString(b64CertDER)
+	if err != nil {
+		panic(err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		panic(err)
+	}
+	return cert
+}
+
+func TestRootsChanged(t *testing.T) {
+	rootSetID1 := storage.RootSetID("1")
+	rootSetID2 := storage.RootSetID("2")
+
+	l := &ctlog.Log{
+		Name: "testtube",
+		URL:  "https://ct.googleapis.com/testtube/",
+	}
+
+	tests := []struct {
+		desc         string
+		rootSetIDs   []storage.RootSetID
+		rootSetCerts map[storage.RootSetID][]*x509.Certificate
+		wantReport   *itestonly.Report
+	}{
+		{
+			desc:       "no changes",
+			rootSetIDs: []storage.RootSetID{rootSetID1, rootSetID1},
+			rootSetCerts: map[storage.RootSetID][]*x509.Certificate{
+				rootSetID1: {root1},
+			},
+		},
+		{
+			desc:       "1 cert added",
+			rootSetIDs: []storage.RootSetID{rootSetID1, rootSetID2},
+			rootSetCerts: map[storage.RootSetID][]*x509.Certificate{
+				rootSetID1: {root1},
+				rootSetID2: {root1, root2},
+			},
+			wantReport: &itestonly.Report{
+				Summary:  "Root certificates changed",
+				Category: "roots",
+				BaseURL:  "https://ct.googleapis.com/testtube/",
+				FullURL:  "https://ct.googleapis.com/testtube/ct/v1/get-roots",
+				Details: `The root certificates accepted by testtube (https://ct.googleapis.com/testtube/) have changed.
+
+Certificates added (1):
+CN=A-Trust-Qual-02,OU=A-Trust-Qual-02,O=A-Trust Ges. f. Sicherheitssysteme im elektr. Datenverkehr GmbH,C=AT (SHA256: 75C9D4361CB96E993ABD9620CF043BE9407A4633F202F0F4C0E17851CC6089CD)
+`,
+			},
+		},
+		{
+			desc:       "2 certs added",
+			rootSetIDs: []storage.RootSetID{rootSetID1, rootSetID2},
+			rootSetCerts: map[storage.RootSetID][]*x509.Certificate{
+				rootSetID1: {},
+				rootSetID2: {root1, root2},
+			},
+			wantReport: &itestonly.Report{
+				Summary:  "Root certificates changed",
+				Category: "roots",
+				BaseURL:  "https://ct.googleapis.com/testtube/",
+				FullURL:  "https://ct.googleapis.com/testtube/ct/v1/get-roots",
+				Details: `The root certificates accepted by testtube (https://ct.googleapis.com/testtube/) have changed.
+
+Certificates added (2):
+CN=A-Trust-Qual-02,OU=A-Trust-Qual-02,O=A-Trust Ges. f. Sicherheitssysteme im elektr. Datenverkehr GmbH,C=AT (SHA256: 75C9D4361CB96E993ABD9620CF043BE9407A4633F202F0F4C0E17851CC6089CD)
+CN=GLOBALTRUST,OU=GLOBALTRUST Certification Service,O=ARGE DATEN - Austrian Society for Data Protection,L=Vienna,ST=Austria,C=AT (SHA256: 5E3571F33F45A7DF1537A68B5FFB9E036AF9D2F5BC4C9717130DC43D7175AAC7)
+`,
+			},
+		},
+		{
+			desc:       "1 cert removed",
+			rootSetIDs: []storage.RootSetID{rootSetID1, rootSetID2},
+			rootSetCerts: map[storage.RootSetID][]*x509.Certificate{
+				rootSetID1: {root1, root2},
+				rootSetID2: {root1},
+			},
+			wantReport: &itestonly.Report{
+				Summary:  "Root certificates changed",
+				Category: "roots",
+				BaseURL:  "https://ct.googleapis.com/testtube/",
+				FullURL:  "https://ct.googleapis.com/testtube/ct/v1/get-roots",
+				Details: `The root certificates accepted by testtube (https://ct.googleapis.com/testtube/) have changed.
+
+Certificates removed (1):
+CN=A-Trust-Qual-02,OU=A-Trust-Qual-02,O=A-Trust Ges. f. Sicherheitssysteme im elektr. Datenverkehr GmbH,C=AT (SHA256: 75C9D4361CB96E993ABD9620CF043BE9407A4633F202F0F4C0E17851CC6089CD)
+`,
+			},
+		},
+		{
+			desc:       "2 certs removed",
+			rootSetIDs: []storage.RootSetID{rootSetID1, rootSetID2},
+			rootSetCerts: map[storage.RootSetID][]*x509.Certificate{
+				rootSetID1: {root1, root2},
+				rootSetID2: {},
+			},
+			wantReport: &itestonly.Report{
+				Summary:  "Root certificates changed",
+				Category: "roots",
+				BaseURL:  "https://ct.googleapis.com/testtube/",
+				FullURL:  "https://ct.googleapis.com/testtube/ct/v1/get-roots",
+				Details: `The root certificates accepted by testtube (https://ct.googleapis.com/testtube/) have changed.
+
+Certificates removed (2):
+CN=A-Trust-Qual-02,OU=A-Trust-Qual-02,O=A-Trust Ges. f. Sicherheitssysteme im elektr. Datenverkehr GmbH,C=AT (SHA256: 75C9D4361CB96E993ABD9620CF043BE9407A4633F202F0F4C0E17851CC6089CD)
+CN=GLOBALTRUST,OU=GLOBALTRUST Certification Service,O=ARGE DATEN - Austrian Society for Data Protection,L=Vienna,ST=Austria,C=AT (SHA256: 5E3571F33F45A7DF1537A68B5FFB9E036AF9D2F5BC4C9717130DC43D7175AAC7)
+`,
+			},
+		},
+		{
+			desc:       "1 cert added, 1 cert removed",
+			rootSetIDs: []storage.RootSetID{rootSetID1, rootSetID2},
+			rootSetCerts: map[storage.RootSetID][]*x509.Certificate{
+				rootSetID1: {root1},
+				rootSetID2: {root2},
+			},
+			wantReport: &itestonly.Report{
+				Summary:  "Root certificates changed",
+				Category: "roots",
+				BaseURL:  "https://ct.googleapis.com/testtube/",
+				FullURL:  "https://ct.googleapis.com/testtube/ct/v1/get-roots",
+				Details: `The root certificates accepted by testtube (https://ct.googleapis.com/testtube/) have changed.
+
+Certificates added (1):
+CN=A-Trust-Qual-02,OU=A-Trust-Qual-02,O=A-Trust Ges. f. Sicherheitssysteme im elektr. Datenverkehr GmbH,C=AT (SHA256: 75C9D4361CB96E993ABD9620CF043BE9407A4633F202F0F4C0E17851CC6089CD)
+
+Certificates removed (1):
+CN=GLOBALTRUST,OU=GLOBALTRUST Certification Service,O=ARGE DATEN - Austrian Society for Data Protection,L=Vienna,ST=Austria,C=AT (SHA256: 5E3571F33F45A7DF1537A68B5FFB9E036AF9D2F5BC4C9717130DC43D7175AAC7)
+`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			test := test
+			t.Parallel()
+
+			fakeStorage := &stestonly.FakeRootsReader{
+				RootSetChan:  make(chan storage.RootSetID, len(test.rootSetIDs)),
+				RootSetCerts: test.rootSetCerts,
+			}
+			fakeReporter := &itestonly.FakeReporter{
+				Updates: make(chan itestonly.Report, 1),
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			go Run(ctx, fakeStorage, fakeReporter, l)
+
+			for _, id := range test.rootSetIDs {
+				fakeStorage.RootSetChan <- id
+			}
+
+			select {
+			case <-ctx.Done():
+				if test.wantReport != nil {
+					t.Errorf("No incident report received before context expired")
+				}
+			case report := <-fakeReporter.Updates:
+				if diff := cmp.Diff(&report, test.wantReport); diff != "" {
+					t.Errorf("Incident report diff (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/storage/testonly/roots.go
+++ b/storage/testonly/roots.go
@@ -1,0 +1,42 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testonly contains fakes for use in tests that interact with storage.
+package testonly
+
+import (
+	"context"
+
+	"github.com/google/certificate-transparency-go/x509"
+	"github.com/google/monologue/ctlog"
+	"github.com/google/monologue/storage"
+)
+
+// FakeRootsReader returns preset values in order to fulfill the storage.RootsReader interface.
+type FakeRootsReader struct {
+	// RootSetChan is returned by WatchRoots.
+	RootSetChan chan storage.RootSetID
+	// RootCerts maps RootSetIDs to sets of certificates. It is used by ReadRoots.
+	RootSetCerts map[storage.RootSetID][]*x509.Certificate
+}
+
+// WatchRoots returns FakeRootsReader.RootSetChan.
+func (f *FakeRootsReader) WatchRoots(ctx context.Context, l *ctlog.Log) (<-chan storage.RootSetID, error) {
+	return f.RootSetChan, nil
+}
+
+// ReadRoots returns FakeRootsReader.RootSetCerts[rootSet].
+func (f *FakeRootsReader) ReadRoots(ctx context.Context, rootSet storage.RootSetID) ([]*x509.Certificate, error) {
+	return f.RootSetCerts[rootSet], nil
+}


### PR DESCRIPTION
Creates incident reports when the root certificates returned by a CT Log's get-roots endpoint change.