### PR TITLE
Pull the MustB64Decode func into testonly package

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/certificate-transparency-go/x509"
 	"github.com/google/certificate-transparency-go/x509util"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/monologue/testonly"
 )
 
 func TestBuildURL(t *testing.T) {
@@ -222,14 +223,6 @@ func TestGetAndParse(t *testing.T) {
 	}
 }
 
-func mustB64Decode(s string) []byte {
-	b, err := base64.StdEncoding.DecodeString(s)
-	if err != nil {
-		panic(err)
-	}
-	return b
-}
-
 func TestGetSTH(t *testing.T) {
 	sthMissingTreeSize := `{"timestamp":1534165797863,"sha256_root_hash":"ygEuQj0whDc1GYzvyAFYMKODrZac2Lu3HOnILxJxIqU=","tree_head_signature":"BAMARjBEAiBNI3ZY018rZ0/mGRyadQpDrO7lnAA2zRTuGNBp4YJV7QIgD6gWqMf3nqxxcl6K4Rg6sFi+FClVL2S8sbN3JhfCAs8="}`
 	sthMissingTimestamp := `{"tree_size":344104340,"sha256_root_hash":"ygEuQj0whDc1GYzvyAFYMKODrZac2Lu3HOnILxJxIqU=","tree_head_signature":"BAMARjBEAiBNI3ZY018rZ0/mGRyadQpDrO7lnAA2zRTuGNBp4YJV7QIgD6gWqMf3nqxxcl6K4Rg6sFi+FClVL2S8sbN3JhfCAs8="}`
@@ -269,8 +262,8 @@ func TestGetSTH(t *testing.T) {
 			wantSTH: &ct.GetSTHResponse{
 				TreeSize:          0,
 				Timestamp:         1534165797863,
-				SHA256RootHash:    mustB64Decode("ygEuQj0whDc1GYzvyAFYMKODrZac2Lu3HOnILxJxIqU="),
-				TreeHeadSignature: mustB64Decode("BAMARjBEAiBNI3ZY018rZ0/mGRyadQpDrO7lnAA2zRTuGNBp4YJV7QIgD6gWqMf3nqxxcl6K4Rg6sFi+FClVL2S8sbN3JhfCAs8="),
+				SHA256RootHash:    testonly.MustB64Decode("ygEuQj0whDc1GYzvyAFYMKODrZac2Lu3HOnILxJxIqU="),
+				TreeHeadSignature: testonly.MustB64Decode("BAMARjBEAiBNI3ZY018rZ0/mGRyadQpDrO7lnAA2zRTuGNBp4YJV7QIgD6gWqMf3nqxxcl6K4Rg6sFi+FClVL2S8sbN3JhfCAs8="),
 			},
 		},
 		{
@@ -281,8 +274,8 @@ func TestGetSTH(t *testing.T) {
 			wantSTH: &ct.GetSTHResponse{
 				TreeSize:          344104340,
 				Timestamp:         0,
-				SHA256RootHash:    mustB64Decode("ygEuQj0whDc1GYzvyAFYMKODrZac2Lu3HOnILxJxIqU="),
-				TreeHeadSignature: mustB64Decode("BAMARjBEAiBNI3ZY018rZ0/mGRyadQpDrO7lnAA2zRTuGNBp4YJV7QIgD6gWqMf3nqxxcl6K4Rg6sFi+FClVL2S8sbN3JhfCAs8="),
+				SHA256RootHash:    testonly.MustB64Decode("ygEuQj0whDc1GYzvyAFYMKODrZac2Lu3HOnILxJxIqU="),
+				TreeHeadSignature: testonly.MustB64Decode("BAMARjBEAiBNI3ZY018rZ0/mGRyadQpDrO7lnAA2zRTuGNBp4YJV7QIgD6gWqMf3nqxxcl6K4Rg6sFi+FClVL2S8sbN3JhfCAs8="),
 			},
 		},
 		{
@@ -310,8 +303,8 @@ func TestGetSTH(t *testing.T) {
 			wantSTH: &ct.GetSTHResponse{
 				TreeSize:          344104340,
 				Timestamp:         1534165797863,
-				SHA256RootHash:    mustB64Decode("ygEuQj0whDc1GYzvyAFYMKODrZac2Lu3HOnILxJxIqU="),
-				TreeHeadSignature: mustB64Decode("BAMARjBEAiBNI3ZY018rZ0/mGRyadQpDrO7lnAA2zRTuGNBp4YJV7QIgD6gWqMf3nqxxcl6K4Rg6sFi+FClVL2S8sbN3JhfCAs8="),
+				SHA256RootHash:    testonly.MustB64Decode("ygEuQj0whDc1GYzvyAFYMKODrZac2Lu3HOnILxJxIqU="),
+				TreeHeadSignature: testonly.MustB64Decode("BAMARjBEAiBNI3ZY018rZ0/mGRyadQpDrO7lnAA2zRTuGNBp4YJV7QIgD6gWqMf3nqxxcl6K4Rg6sFi+FClVL2S8sbN3JhfCAs8="),
 			},
 		},
 	}
@@ -852,11 +845,11 @@ func TestGetProofByHash(t *testing.T) {
 			wantResponse: &ct.GetProofByHashResponse{
 				LeafIndex: 10,
 				AuditPath: [][]byte{
-					mustB64Decode("pWAVPaJIQdVdHgm/GWo/tf0a0gaG4JjCanqHc49kxpU="),
-					mustB64Decode("+05OCiIkipWWDKhByJGctdwLiSo1geIvWF8pDGv2VFw="),
-					mustB64Decode("aBTbMciBy2Ey35az07wjEiFN1kWn+37LVa07BQCH2qo="),
-					mustB64Decode("t+sKhOFhVnTT/6bmOSyVWKfGagwJBVvcyynO2oJLxsY="),
-					mustB64Decode("LRdkcLMeof0FdRmX6IVaDTITWJUr8eABhUaHa0vcWNw="),
+					testonly.MustB64Decode("pWAVPaJIQdVdHgm/GWo/tf0a0gaG4JjCanqHc49kxpU="),
+					testonly.MustB64Decode("+05OCiIkipWWDKhByJGctdwLiSo1geIvWF8pDGv2VFw="),
+					testonly.MustB64Decode("aBTbMciBy2Ey35az07wjEiFN1kWn+37LVa07BQCH2qo="),
+					testonly.MustB64Decode("t+sKhOFhVnTT/6bmOSyVWKfGagwJBVvcyynO2oJLxsY="),
+					testonly.MustB64Decode("LRdkcLMeof0FdRmX6IVaDTITWJUr8eABhUaHa0vcWNw="),
 				},
 			},
 		},
@@ -870,7 +863,7 @@ func TestGetProofByHash(t *testing.T) {
 				lc = New(test.url, &http.Client{})
 			}
 
-			gotResp, gotHTTPData, gotErr := lc.GetProofByHash(mustB64Decode(leafHash), treeSize)
+			gotResp, gotHTTPData, gotErr := lc.GetProofByHash(testonly.MustB64Decode(leafHash), treeSize)
 			if gotErrType := reflect.TypeOf(gotErr); gotErrType != test.wantErrType {
 				t.Errorf("GetProofByHash(%s, %d): error was of type %v, want %v", leafHash, treeSize, gotErrType, test.wantErrType)
 			}
@@ -1060,9 +1053,9 @@ func TestAddChain(t *testing.T) {
 			statusCode: http.StatusOK,
 			rspBody:    []byte(sctMissingTimestamp),
 			wantSCT: &ct.AddChainResponse{
-				ID:        mustB64Decode("CEEUmABxUywWGQRgvPxH/cJlOvopLHKzf/hjrinMyfA="),
+				ID:        testonly.MustB64Decode("CEEUmABxUywWGQRgvPxH/cJlOvopLHKzf/hjrinMyfA="),
 				Timestamp: 0,
-				Signature: mustB64Decode("BAMARjBEAiAJAPO7EKykH4eOQ81kTzKCb4IEWzcxTBdbdRCHLFPLFAIgBEoGXDUtcIaF3M5HWI+MxwkCQbvqR9TSGUHDCZoOr3Q="),
+				Signature: testonly.MustB64Decode("BAMARjBEAiAJAPO7EKykH4eOQ81kTzKCb4IEWzcxTBdbdRCHLFPLFAIgBEoGXDUtcIaF3M5HWI+MxwkCQbvqR9TSGUHDCZoOr3Q="),
 			},
 		},
 		{
@@ -1076,9 +1069,9 @@ func TestAddChain(t *testing.T) {
 			statusCode: http.StatusOK,
 			rspBody:    []byte(sct),
 			wantSCT: &ct.AddChainResponse{
-				ID:        mustB64Decode("CEEUmABxUywWGQRgvPxH/cJlOvopLHKzf/hjrinMyfA="),
+				ID:        testonly.MustB64Decode("CEEUmABxUywWGQRgvPxH/cJlOvopLHKzf/hjrinMyfA="),
 				Timestamp: 1512556025588,
-				Signature: mustB64Decode("BAMARjBEAiAJAPO7EKykH4eOQ81kTzKCb4IEWzcxTBdbdRCHLFPLFAIgBEoGXDUtcIaF3M5HWI+MxwkCQbvqR9TSGUHDCZoOr3Q="),
+				Signature: testonly.MustB64Decode("BAMARjBEAiAJAPO7EKykH4eOQ81kTzKCb4IEWzcxTBdbdRCHLFPLFAIgBEoGXDUtcIaF3M5HWI+MxwkCQbvqR9TSGUHDCZoOr3Q="),
 			},
 		},
 	}

--- a/sthgetter/sthgetter_test.go
+++ b/sthgetter/sthgetter_test.go
@@ -15,31 +15,22 @@
 package sthgetter
 
 import (
-	"encoding/base64"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/monologue/ctlog"
+	"github.com/google/monologue/testonly"
 )
-
-func mustB64Decode(b64 string) []byte {
-	b, err := base64.StdEncoding.DecodeString(b64)
-	if err != nil {
-		panic(fmt.Sprintf("error decoding %s: %s", b64, err))
-	}
-	return b
-}
 
 var (
 	// A valid STH from the Google Pilot Log.
 	validSTH = &ct.GetSTHResponse{
 		TreeSize:          580682455,
 		Timestamp:         1554897886201, // 2019-04-10 12:04:46.201 UTC
-		SHA256RootHash:    mustB64Decode("VicMkhzrGNv+lNCwXRVHH0WniZuDg3IXhgPai5kyHdA="),
-		TreeHeadSignature: mustB64Decode("BAMARzBFAiEAs0GiYnPT5ZQJ2LGLhLmIXZXSLg+N+CxTkJL75tECEqgCIBZzJGyzH9h+IL63XCvRlfTKhLvzSxVicrT30+rwTSU0"),
+		SHA256RootHash:    testonly.MustB64Decode("VicMkhzrGNv+lNCwXRVHH0WniZuDg3IXhgPai5kyHdA="),
+		TreeHeadSignature: testonly.MustB64Decode("BAMARzBFAiEAs0GiYnPT5ZQJ2LGLhLmIXZXSLg+N+CxTkJL75tECEqgCIBZzJGyzH9h+IL63XCvRlfTKhLvzSxVicrT30+rwTSU0"),
 	}
 	// The public key for the Google Pilot Log.
 	b64PubKey = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfahLEimAoz2t01p3uMziiLOl/fHTDM0YDOhBRuiBARsV4UvxG2LdNgoIGLrtCzWE0J5APC2em4JlvR8EEEFMoA=="

--- a/testonly/testonly.go
+++ b/testonly/testonly.go
@@ -1,0 +1,11 @@
+package testonly
+
+import "encoding/base64"
+
+func MustB64Decode(b64 string) []byte {
+	b, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/testonly/testonly.go
+++ b/testonly/testonly.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package sthgetter periodically gets an STH from a Log, checks that each one
-// meets per-STH requirements defined in RFC 6962, and stores them.
+// Package testonly contains resources used during testing by multiple of the
+// monologue packages.
 package testonly
 
 import "encoding/base64"

--- a/testonly/testonly.go
+++ b/testonly/testonly.go
@@ -1,3 +1,19 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sthgetter periodically gets an STH from a Log, checks that each one
+// meets per-STH requirements defined in RFC 6962, and stores them.
 package testonly
 
 import "encoding/base64"


### PR DESCRIPTION
Multiple modules use this during testing, and rather than have it
duplicated in every module, let's put it in a central "testing
resources" place.