### PR TITLE
Don't index the whole Summary field as it's too large.

### DIFF
--- a/incident/mysql/incident.sql
+++ b/incident/mysql/incident.sql
@@ -16,6 +16,8 @@ CREATE TABLE IF NOT EXISTS Incidents(
 CREATE INDEX TimestampIndex ON Incidents(Timestamp);
 CREATE INDEX SourceIndex ON Incidents(Source);
 CREATE INDEX BaseURLIndex ON Incidents(BaseURL);
-CREATE INDEX SummaryIndex ON Incidents(Summary);
+// Indexing the whole Summary field exceeds the 3K key limit on multi-byte
+// character sets.
+CREATE INDEX SummaryIndex ON Incidents(Summary(512));
 CREATE INDEX FullURLIndex ON Incidents(FullURL);
 CREATE INDEX CategoryIndex ON Incidents(Category);


### PR DESCRIPTION
For multi-byte characters the key exceeds the MySQL limit of 3K (or even less on older versions).

This SQL is brought in by CT tests so needs to be worked around now. There are alternate solutions if this code is going to be used in future.