### PR TITLE
Make Travis cache the directory where Go Modules are stored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ go_import_path: github.com/google/monologue
 go:
   - 1.13
 
+cache:
+  directories:
+    - $GOPATH/pkg/mod
+
 env:
   global:
     - GO111MODULE=on


### PR DESCRIPTION
This saves it having to repeatedly download the same modules, which will make builds faster.