### PR TITLE
Bump Go from 1.13 to 1.18

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,7 +16,7 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - megacheck
     - misspell
     - govet

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ version: ~> 1.0
 language: go
 go_import_path: github.com/google/monologue
 go:
-  - 1.13
+  - 1.18
 
 services:
   - mysql
@@ -10,10 +10,6 @@ services:
 cache:
   directories:
     - $GOPATH/pkg/mod
-
-env:
-  global:
-    - GO111MODULE=on
 
 jobs:
   include:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/monologue
 
-go 1.13
+go 1.18
 
 require (
 	github.com/go-sql-driver/mysql v1.5.0
@@ -9,4 +9,150 @@ require (
 	github.com/google/go-cmp v0.4.0
 	github.com/google/trillian v1.3.3
 	github.com/kylelemons/godebug v1.1.0
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
+	github.com/OpenPeeDeeP/depguard v1.0.1 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/bombsimon/wsl v1.2.8 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/coreos/bbolt v1.3.3 // indirect
+	github.com/coreos/etcd v3.3.17+incompatible // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a // indirect
+	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
+	github.com/cpuguy83/go-md2man v1.0.10 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/emicklei/proto v1.8.0 // indirect
+	github.com/fatih/color v1.7.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/fullstorydev/grpcurl v1.4.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db // indirect
+	github.com/go-lintpack/lintpack v0.5.2 // indirect
+	github.com/go-toolsmith/astcast v1.0.0 // indirect
+	github.com/go-toolsmith/astcopy v1.0.0 // indirect
+	github.com/go-toolsmith/astequal v1.0.0 // indirect
+	github.com/go-toolsmith/astfmt v1.0.0 // indirect
+	github.com/go-toolsmith/astp v1.0.0 // indirect
+	github.com/go-toolsmith/strparse v1.0.0 // indirect
+	github.com/go-toolsmith/typep v1.0.0 // indirect
+	github.com/gobuffalo/flect v0.1.6 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gofrs/flock v0.7.1 // indirect
+	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
+	github.com/golang/mock v1.3.1 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2 // indirect
+	github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a // indirect
+	github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6 // indirect
+	github.com/golangci/go-misc v0.0.0-20180628070357-927a3d87b613 // indirect
+	github.com/golangci/goconst v0.0.0-20180610141641-041c5f2b40f3 // indirect
+	github.com/golangci/gocyclo v0.0.0-20180528144436-0a533e8fa43d // indirect
+	github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a // indirect
+	github.com/golangci/golangci-lint v1.21.0 // indirect
+	github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc // indirect
+	github.com/golangci/lint-1 v0.0.0-20191013205115-297bf364a8e0 // indirect
+	github.com/golangci/maligned v0.0.0-20180506175553-b1d89398deca // indirect
+	github.com/golangci/misspell v0.0.0-20180809174111-950f5d19e770 // indirect
+	github.com/golangci/prealloc v0.0.0-20180630174525-215b22d4de21 // indirect
+	github.com/golangci/revgrep v0.0.0-20180812185044-276a5c0a1039 // indirect
+	github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4 // indirect
+	github.com/google/btree v1.0.0 // indirect
+	github.com/google/uuid v1.1.1 // indirect
+	github.com/gorilla/websocket v1.4.1 // indirect
+	github.com/gostaticanalysis/analysisutil v0.0.3 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.11.2 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/huandu/xstrings v1.2.0 // indirect
+	github.com/imdario/mergo v0.3.8 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jhump/protoreflect v1.5.0 // indirect
+	github.com/jonboulle/clockwork v0.1.0 // indirect
+	github.com/json-iterator/go v1.1.8 // indirect
+	github.com/kisielk/gotool v1.0.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/lyft/protoc-gen-validate v0.1.0 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/matoous/godox v0.0.0-20190911065817-5d6d842e92eb // indirect
+	github.com/mattn/go-colorable v0.1.4 // indirect
+	github.com/mattn/go-isatty v0.0.10 // indirect
+	github.com/mattn/go-runewidth v0.0.6 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/mitchellh/reflectwalk v1.0.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/mwitkow/go-proto-validators v0.2.0 // indirect
+	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d // indirect
+	github.com/olekukonko/tablewriter v0.0.2 // indirect
+	github.com/pelletier/go-toml v1.6.0 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.2.1 // indirect
+	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
+	github.com/prometheus/common v0.7.0 // indirect
+	github.com/prometheus/procfs v0.0.6 // indirect
+	github.com/pseudomuto/protoc-gen-doc v1.3.0 // indirect
+	github.com/pseudomuto/protokit v0.2.0 // indirect
+	github.com/russross/blackfriday v2.0.0+incompatible // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/securego/gosec v0.0.0-20191104154532-b4c76d4234af // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.4.2 // indirect
+	github.com/soheilhy/cmux v0.1.4 // indirect
+	github.com/sourcegraph/go-diff v0.5.1 // indirect
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/cobra v0.0.5 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/viper v1.5.0 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/stretchr/testify v1.4.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e // indirect
+	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
+	github.com/uber/prototool v1.9.0 // indirect
+	github.com/ultraware/funlen v0.0.2 // indirect
+	github.com/ultraware/whitespace v0.0.4 // indirect
+	github.com/urfave/cli v1.22.1 // indirect
+	github.com/uudashr/gocognit v1.0.0 // indirect
+	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
+	go.etcd.io/etcd v3.3.17+incompatible // indirect
+	go.uber.org/atomic v1.5.0 // indirect
+	go.uber.org/multierr v1.4.0 // indirect
+	go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee // indirect
+	go.uber.org/zap v1.13.0 // indirect
+	golang.org/x/crypto v0.0.0-20191112222119-e1110fd1c708 // indirect
+	golang.org/x/lint v0.0.0-20190930215403-16217165b5de // indirect
+	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
+	golang.org/x/sys v0.0.0-20191115151921-52ab43148777 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	golang.org/x/tools v0.0.0-20191114222411-4191b8cbba09 // indirect
+	google.golang.org/genproto v0.0.0-20191114150713-6bbd007550de // indirect
+	google.golang.org/grpc v1.25.1 // indirect
+	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
+	gopkg.in/yaml.v2 v2.2.5 // indirect
+	honnef.co/go/tools v0.0.1-2019.2.3 // indirect
+	mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed // indirect
+	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
+	mvdan.cc/unparam v0.0.0-20191111180625-960b1ec0f2c2 // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
+	sourcegraph.com/sqs/pbtypes v1.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -69,7 +69,6 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -84,10 +84,6 @@ main() {
     echo 'running go build'
     go build ./...
 
-    # Install test deps so that individual test runs below can reuse them.
-    echo 'installing test deps'
-    go test -i ./...
-
     local coverflags=""
     if [[ ${coverage} -eq 1 ]]; then
         coverflags="-covermode=atomic -coverprofile=coverage.txt"


### PR DESCRIPTION
Presubmit result
```zsh
@roger2hk ➜ /workspaces/monologue (bump-go-1.18 ✗) $ ./scripts/presubmit.sh
running go build
running go test
ok      github.com/google/monologue/apicall     (cached)
ok      github.com/google/monologue/certgen     (cached)
ok      github.com/google/monologue/certsubmitter       (cached)
ok      github.com/google/monologue/client      (cached)
?       github.com/google/monologue/collector   [no test files]
?       github.com/google/monologue/collector/datacollector     [no test files]
ok      github.com/google/monologue/ctlog       (cached)
?       github.com/google/monologue/errors      [no test files]
?       github.com/google/monologue/incident    [no test files]
ok      github.com/google/monologue/incident/mysql      0.006s
?       github.com/google/monologue/incident/testonly   [no test files]
ok      github.com/google/monologue/interval    (cached)
ok      github.com/google/monologue/rootsanalyzer       (cached)
?       github.com/google/monologue/rootsgetter [no test files]
ok      github.com/google/monologue/sthgetter   (cached)
?       github.com/google/monologue/storage     [no test files]
ok      github.com/google/monologue/storage/mysql       0.010s
?       github.com/google/monologue/storage/mysql/testdb        [no test files]
?       github.com/google/monologue/storage/print       [no test files]
?       github.com/google/monologue/storage/testonly    [no test files]
?       github.com/google/monologue/testonly    [no test files]
running golangci-lint
checking license headers
```